### PR TITLE
[#8] feat: 가점-공고 연결 및 접근 제어 구현

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Disclaimer from '@/components/Disclaimer';
-import type { Announcement } from '@/types';
+import type { Announcement, StoredScoreData } from '@/types';
 import { getDday } from '@/lib/announcements';
 
 const REGION_OPTIONS = [
@@ -27,12 +27,38 @@ const REGION_OPTIONS = [
   '제주특별자치도',
 ];
 
+const tierBadgeStyle: Record<string, string> = {
+  S: 'bg-yellow-100 text-yellow-700',
+  A: 'bg-blue-100 text-blue-700',
+  B: 'bg-green-100 text-green-700',
+  C: 'bg-gray-100 text-gray-700',
+};
+
 export default function AnnouncementsPage() {
   const router = useRouter();
+  const [scoreData, setScoreData] = useState<StoredScoreData | null>(null);
+  const [authChecked, setAuthChecked] = useState(false);
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedRegion, setSelectedRegion] = useState('전체');
   const [isMock, setIsMock] = useState(false);
+  const [hideExpired, setHideExpired] = useState(true);
+
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem('scoreData');
+      if (!raw) {
+        router.push('/calculator');
+        return;
+      }
+      const parsed: StoredScoreData = JSON.parse(raw);
+      setScoreData(parsed);
+    } catch {
+      router.push('/calculator');
+    } finally {
+      setAuthChecked(true);
+    }
+  }, [router]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -52,6 +78,18 @@ export default function AnnouncementsPage() {
     };
     fetchData();
   }, [selectedRegion]);
+
+  const filteredAnnouncements = hideExpired
+    ? announcements.filter(a => a.status !== '마감')
+    : announcements;
+
+  if (!authChecked) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-8 h-8 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
 
   return (
     <main className="min-h-screen bg-gray-50">
@@ -96,9 +134,40 @@ export default function AnnouncementsPage() {
           </div>
         </div>
 
-        {/* Region Filter */}
+        {/* Score Summary Bar */}
+        {scoreData && (
+          <div className="flex items-center justify-between bg-blue-50 border border-blue-200 rounded-xl px-4 py-3 mb-4">
+            <div className="flex items-center gap-3">
+              <span className="text-sm text-gray-600">내 가점</span>
+              <span className="text-lg font-bold text-blue-700">{scoreData.result.totalScore}점</span>
+              <span className="text-xs text-gray-500">/ 84점</span>
+              <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${tierBadgeStyle[scoreData.result.tier]}`}>
+                {scoreData.result.tier}등급
+              </span>
+            </div>
+            <button
+              onClick={() => router.push('/calculator')}
+              className="text-xs text-blue-600 underline"
+            >
+              재계산
+            </button>
+          </div>
+        )}
+
+        {/* Region Filter & Expired Toggle */}
         <div className="mb-4">
-          <p className="text-xs font-semibold text-gray-500 mb-2">지역 필터</p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-semibold text-gray-500">지역 필터</p>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-gray-500">마감 포함</span>
+              <button
+                onClick={() => setHideExpired(!hideExpired)}
+                className={`relative w-10 h-5 rounded-full transition-colors ${hideExpired ? 'bg-gray-300' : 'bg-blue-500'}`}
+              >
+                <span className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${hideExpired ? 'left-0.5' : 'left-5'}`} />
+              </button>
+            </div>
+          </div>
           <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
             {REGION_OPTIONS.map((region) => (
               <button
@@ -149,7 +218,7 @@ export default function AnnouncementsPage() {
               </div>
             ))}
           </div>
-        ) : announcements.length === 0 ? (
+        ) : filteredAnnouncements.length === 0 ? (
           <div className="text-center py-12">
             <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-3">
               <svg
@@ -171,16 +240,16 @@ export default function AnnouncementsPage() {
           </div>
         ) : (
           <div className="space-y-3">
-            {announcements.map((item) => (
+            {filteredAnnouncements.map((item) => (
               <AnnouncementCard key={item.id} announcement={item} />
             ))}
           </div>
         )}
 
         {/* Total count */}
-        {!loading && announcements.length > 0 && (
+        {!loading && filteredAnnouncements.length > 0 && (
           <p className="text-xs text-gray-400 text-center mt-4">
-            총 {announcements.length}건의 공고
+            총 {filteredAnnouncements.length}건의 공고
           </p>
         )}
 

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -3,10 +3,9 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { Suspense } from 'react';
-import Link from 'next/link';
 import Disclaimer from '@/components/Disclaimer';
 import { calculateTotalScore, calculateSpecialSupply } from '@/lib/calculator';
-import type { EligibilityInput, ScoreResult, SpecialSupplyEligibility } from '@/types';
+import type { EligibilityInput, ScoreResult, SpecialSupplyEligibility, StoredScoreData } from '@/types';
 
 function ResultContent() {
   const searchParams = useSearchParams();
@@ -26,6 +25,15 @@ function ResultContent() {
       setInput(parsed);
       setScoreResult(calculateTotalScore(parsed));
       setSpecialSupply(calculateSpecialSupply(parsed));
+      const scoreData: StoredScoreData = {
+        input: parsed,
+        result: calculateTotalScore(parsed),
+        specialSupply: calculateSpecialSupply(parsed),
+        savedAt: Date.now(),
+      };
+      try {
+        sessionStorage.setItem('scoreData', JSON.stringify(scoreData));
+      } catch {}
     } catch {
       router.push('/calculator');
     }
@@ -201,16 +209,16 @@ function ResultContent() {
         </div>
 
         {/* Action Buttons */}
-        <div className="space-y-3 mb-4">
-          <Link
-            href="/announcements"
-            className="block w-full text-center py-4 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl shadow-md transition-colors"
+        <div className="flex gap-3 mb-4">
+          <button
+            onClick={() => router.push('/announcements')}
+            className="flex-1 text-center py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl shadow-md transition-colors px-6"
           >
-            청약 공고 보러가기
-          </Link>
+            내 점수로 공고 보기
+          </button>
           <button
             onClick={() => router.push('/calculator')}
-            className="block w-full text-center py-3.5 bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 font-semibold rounded-xl transition-colors"
+            className="flex-1 text-center py-3 bg-white border border-gray-300 hover:bg-gray-50 text-gray-700 font-semibold rounded-xl transition-colors px-6"
           >
             다시 계산하기
           </button>

--- a/types/index.ts
+++ b/types/index.ts
@@ -37,6 +37,14 @@ export interface SpecialSupplyEligibility {
   multiChild: boolean; // 다자녀
 }
 
+// sessionStorage 저장 스키마
+export interface StoredScoreData {
+  input: EligibilityInput;
+  result: ScoreResult;
+  specialSupply: SpecialSupplyEligibility;
+  savedAt: number;
+}
+
 // 청약 접수 상태 타입
 export type SubscriptionStatus = '접수중' | '접수예정' | '마감';
 


### PR DESCRIPTION
## Summary
- 가점 계산 완료 후 결과 페이지에서 `/announcements`로 이동하는 CTA 버튼 추가
- `/announcements` 진입 시 sessionStorage에 가점 데이터 없으면 `/calculator`로 리다이렉트
- 공고 페이지 상단에 내 가점 요약 표시 (X점 / 84점, X등급)
- 마감 공고 기본 숨김 + "마감 포함" 토글 옵션 제공
- `hideExpired` 파라미터 클라이언트 사이드 필터링으로 처리

## Test plan
- [ ] 가점 계산 완료 후 결과 페이지 → "내 점수로 공고 보기" 버튼 클릭 → `/announcements` 이동 확인
- [ ] sessionStorage 비운 상태에서 `/announcements` 직접 접근 → `/calculator` 리다이렉트 확인
- [ ] 공고 페이지 상단 가점 요약 (점수, 등급) 표시 확인
- [ ] 마감 공고 기본 숨김 / 토글 ON 시 마감 공고 포함 확인

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)