### PR TITLE
[#16] feat: 특별공급 자격 판정 정확화

### DIFF
--- a/app/calculator/page.tsx
+++ b/app/calculator/page.tsx
@@ -39,6 +39,8 @@ const defaultInput: EligibilityInput = {
   subscriptionBalance: 0,
   region: '',
   isMarried: false,
+  marriageDate: '',
+  childrenCount: 0,
   hasRecentChild: false,
 };
 
@@ -135,6 +137,8 @@ export default function CalculatorPage() {
           {step === 5 && (
             <Step5
               isMarried={input.isMarried}
+              marriageDate={input.marriageDate}
+              childrenCount={input.childrenCount}
               hasRecentChild={input.hasRecentChild}
               onChange={updateInput}
             />
@@ -487,16 +491,39 @@ function Step4({
 // Step 5: 혼인 및 자녀 정보
 function Step5({
   isMarried,
+  marriageDate,
+  childrenCount,
   hasRecentChild,
   onChange,
 }: {
   isMarried: boolean;
+  marriageDate: string;
+  childrenCount: number;
   hasRecentChild: boolean;
   onChange: <K extends keyof EligibilityInput>(
     key: K,
     value: EligibilityInput[K],
   ) => void;
 }) {
+  const today = new Date().toISOString().slice(0, 7);
+
+  const marriageYearsHint = (() => {
+    if (!marriageDate) return null;
+    const [y, m] = marriageDate.split('-').map(Number);
+    if (!y || !m) return null;
+    const diffMs = new Date().getTime() - new Date(y, m - 1, 1).getTime();
+    const totalMonths = Math.floor(diffMs / (1000 * 60 * 60 * 24 * 30.44));
+    const years = Math.floor(totalMonths / 12);
+    const months = totalMonths % 12;
+    const label = years > 0 ? `${years}년 ${months > 0 ? `${months}개월` : ''}`.trim() : `${months}개월`;
+    const eligible = diffMs / (1000 * 60 * 60 * 24 * 365.25) <= 7;
+    return eligible ? `혼인 ${label} → 신혼부부 특공 자격 있음` : `혼인 ${label} → 7년 초과로 자격 없음`;
+  })();
+
+  const childrenHint = childrenCount >= 3
+    ? '다자녀 특공 자격 있음'
+    : `${3 - childrenCount}명 더 있으면 다자녀 특공 가능`;
+
   return (
     <div>
       <h2 className="text-lg font-bold text-gray-900 mb-1">혼인 및 자녀</h2>
@@ -505,39 +532,79 @@ function Step5({
       </p>
 
       <div className="space-y-4">
+        {/* 혼인 여부 */}
         <div>
-          <p className="text-sm font-semibold text-gray-700 mb-2">
-            혼인 여부
-          </p>
+          <p className="text-sm font-semibold text-gray-700 mb-2">혼인 여부</p>
           <div className="flex gap-3">
             <button
               onClick={() => onChange('isMarried', true)}
               className={`flex-1 py-3 rounded-xl border-2 font-semibold text-sm transition-all ${
-                isMarried
-                  ? 'border-blue-600 bg-blue-50 text-blue-700'
-                  : 'border-gray-200 bg-white text-gray-600'
+                isMarried ? 'border-blue-600 bg-blue-50 text-blue-700' : 'border-gray-200 bg-white text-gray-600'
               }`}
             >
               기혼
             </button>
             <button
-              onClick={() => onChange('isMarried', false)}
+              onClick={() => {
+                onChange('isMarried', false);
+                onChange('marriageDate', '');
+              }}
               className={`flex-1 py-3 rounded-xl border-2 font-semibold text-sm transition-all ${
-                !isMarried
-                  ? 'border-blue-600 bg-blue-50 text-blue-700'
-                  : 'border-gray-200 bg-white text-gray-600'
+                !isMarried ? 'border-blue-600 bg-blue-50 text-blue-700' : 'border-gray-200 bg-white text-gray-600'
               }`}
             >
               미혼
             </button>
           </div>
-          {isMarried && (
-            <p className="text-xs text-blue-600 mt-1.5">
-              신혼부부 특별공급 자격 검토 가능
-            </p>
-          )}
         </div>
 
+        {/* 혼인 날짜 — 기혼일 때만 표시 */}
+        {isMarried && (
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1.5">
+              혼인 날짜
+            </label>
+            <input
+              type="month"
+              max={today}
+              value={marriageDate}
+              onChange={(e) => onChange('marriageDate', e.target.value)}
+              className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-800"
+            />
+            {marriageYearsHint && (
+              <p className={`text-xs mt-1 ${marriageYearsHint.includes('없음') ? 'text-red-500' : 'text-blue-500'}`}>
+                💡 {marriageYearsHint}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* 미성년 자녀 수 */}
+        <div>
+          <p className="text-sm font-semibold text-gray-700 mb-2">
+            미성년 자녀 수 <span className="font-normal text-gray-400">(만 19세 미만)</span>
+          </p>
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => onChange('childrenCount', Math.max(0, childrenCount - 1))}
+              className="w-12 h-12 rounded-xl border-2 border-gray-200 text-xl font-bold text-gray-600 hover:border-blue-400 transition-colors flex items-center justify-center"
+            >
+              −
+            </button>
+            <span className="text-2xl font-bold text-gray-900 w-8 text-center">{childrenCount}</span>
+            <button
+              onClick={() => onChange('childrenCount', childrenCount + 1)}
+              className="w-12 h-12 rounded-xl border-2 border-gray-200 text-xl font-bold text-gray-600 hover:border-blue-400 transition-colors flex items-center justify-center"
+            >
+              +
+            </button>
+          </div>
+          <p className={`text-xs mt-1.5 ${childrenCount >= 3 ? 'text-blue-500' : 'text-gray-400'}`}>
+            💡 {childrenHint}
+          </p>
+        </div>
+
+        {/* 최근 2년 이내 출산 */}
         <div>
           <p className="text-sm font-semibold text-gray-700 mb-2">
             최근 2년 이내 자녀 출산 여부
@@ -546,9 +613,7 @@ function Step5({
             <button
               onClick={() => onChange('hasRecentChild', true)}
               className={`flex-1 py-3 rounded-xl border-2 font-semibold text-sm transition-all ${
-                hasRecentChild
-                  ? 'border-blue-600 bg-blue-50 text-blue-700'
-                  : 'border-gray-200 bg-white text-gray-600'
+                hasRecentChild ? 'border-blue-600 bg-blue-50 text-blue-700' : 'border-gray-200 bg-white text-gray-600'
               }`}
             >
               있음
@@ -556,25 +621,20 @@ function Step5({
             <button
               onClick={() => onChange('hasRecentChild', false)}
               className={`flex-1 py-3 rounded-xl border-2 font-semibold text-sm transition-all ${
-                !hasRecentChild
-                  ? 'border-blue-600 bg-blue-50 text-blue-700'
-                  : 'border-gray-200 bg-white text-gray-600'
+                !hasRecentChild ? 'border-blue-600 bg-blue-50 text-blue-700' : 'border-gray-200 bg-white text-gray-600'
               }`}
             >
               없음
             </button>
           </div>
           {hasRecentChild && (
-            <p className="text-xs text-blue-600 mt-1.5">
-              출산가구 우대 혜택 적용 가능
-            </p>
+            <p className="text-xs text-blue-600 mt-1.5">출산가구 우대 혜택 적용 가능</p>
           )}
         </div>
 
         <div className="p-3 bg-amber-50 border border-amber-200 rounded-xl">
           <p className="text-xs text-amber-700">
-            혼인 기간 7년 이내이면 신혼부부 특별공급 신청이 가능합니다.
-            정확한 자격은 공고문을 확인하세요.
+            정확한 특별공급 자격은 공고문을 반드시 확인하세요.
           </p>
         </div>
       </div>

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -195,7 +195,21 @@ function ResultContent() {
             <SpecialBadge
               label="신혼부부 특별공급"
               eligible={specialSupply.newlyWed}
-              description="혼인 상태 (7년 이내 해당 가능)"
+              description={
+                !input.isMarried
+                  ? '미혼'
+                  : !input.marriageDate
+                  ? '혼인 날짜 미입력'
+                  : (() => {
+                      const [y, m] = input.marriageDate.split('-').map(Number);
+                      const diffMs = new Date().getTime() - new Date(y, m - 1, 1).getTime();
+                      const totalMonths = Math.floor(diffMs / (1000 * 60 * 60 * 24 * 30.44));
+                      const years = Math.floor(totalMonths / 12);
+                      const months = totalMonths % 12;
+                      const label = years > 0 ? `혼인 ${years}년 ${months > 0 ? `${months}개월` : ''}`.trim() : `혼인 ${months}개월`;
+                      return specialSupply.newlyWed ? `${label} → 자격 있음` : `${label} → 7년 초과`;
+                    })()
+              }
             />
             <SpecialBadge
               label="생애최초 특별공급"
@@ -205,7 +219,7 @@ function ResultContent() {
             <SpecialBadge
               label="다자녀 특별공급"
               eligible={specialSupply.multiChild}
-              description="미성년 자녀 3명 이상 (간략 판정)"
+              description={`미성년 자녀 ${input.childrenCount ?? 0}명${specialSupply.multiChild ? ' → 자격 있음' : ' (3명 이상 필요)'}`}
             />
           </div>
           <p className="text-xs text-gray-400 mt-3">

--- a/docs/technical/issue-16-special-supply-accuracy.md
+++ b/docs/technical/issue-16-special-supply-accuracy.md
@@ -1,0 +1,102 @@
+# Issue #16 기술 설계: 특별공급 자격 판정 정확화
+
+## 개요
+
+신혼부부(혼인 7년 이내), 다자녀(미성년 자녀 3명 이상) 기준을 실제 제도에 맞게 구현합니다.
+
+## 타입 변경 (`types/index.ts`)
+
+```ts
+export interface EligibilityInput {
+  // ... 기존 필드 유지 ...
+
+  // 혼인/자녀 — 기존
+  isMarried: boolean;
+  hasRecentChild: boolean;
+
+  // 혼인/자녀 — 신규
+  marriageDate: string;    // YYYY-MM, 기혼일 때만 유효
+  childrenCount: number;   // 미성년(만 19세 미만) 자녀 수
+}
+```
+
+## 기본값 변경 (`app/calculator/page.tsx`)
+
+```ts
+const defaultInput: EligibilityInput = {
+  // ... 기존 ...
+  marriageDate: '',
+  childrenCount: 0,
+};
+```
+
+## 계산 로직 변경 (`lib/calculator.ts`)
+
+### 신혼부부: 혼인 7년 이내 계산
+
+```ts
+function calcMarriageYears(marriageDate: string): number {
+  if (!marriageDate) return Infinity;
+  const [year, month] = marriageDate.split('-').map(Number);
+  const start = new Date(year, month - 1, 1);
+  const now = new Date();
+  return (now.getTime() - start.getTime()) / (1000 * 60 * 60 * 24 * 365.25);
+}
+
+// 신혼부부: 기혼 + 혼인 7년 이내
+const newlyWed = input.isMarried && calcMarriageYears(input.marriageDate) <= 7;
+```
+
+### 다자녀: childrenCount 직접 사용
+
+```ts
+// 다자녀: 미성년 자녀 3명 이상
+const multiChild = input.childrenCount >= 3;
+```
+
+## UI 변경 (`app/calculator/page.tsx` — Step 5)
+
+```tsx
+// 혼인 날짜: isMarried=true일 때만 표시
+{isMarried && (
+  <div>
+    <label>혼인 날짜</label>
+    <input type="month" max={today} value={marriageDate}
+      onChange={(e) => onChange('marriageDate', e.target.value)} />
+    {marriageYearsHint && <p>💡 {marriageYearsHint}</p>}
+  </div>
+)}
+
+// 미성년 자녀 수: ± 버튼
+<div>
+  <label>미성년 자녀 수 (만 19세 미만)</label>
+  <PlusMinusInput value={childrenCount}
+    onChange={(v) => onChange('childrenCount', v)} />
+  <p>{childrenCount >= 3 ? '💡 다자녀 특공 자격 있음' : `💡 ${3 - childrenCount}명 더 있으면 자격`}</p>
+</div>
+```
+
+## 결과 페이지 변경 (`app/result/page.tsx`)
+
+특별공급 카드 아래에 판정 근거 문구 추가:
+- 신혼부부: "혼인 N년 N개월" 또는 "혼인 7년 초과 — 자격 없음"
+- 다자녀: "미성년 자녀 N명"
+
+## 하위 호환 처리
+
+기존 sessionStorage에 `marriageDate`, `childrenCount`가 없을 경우:
+- `marriageDate`: `''` → 신혼부부 판정 시 미입력으로 처리 (기혼이어도 미입력 시 false)
+- `childrenCount`: `undefined ?? 0`
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `types/index.ts` | EligibilityInput에 marriageDate, childrenCount 추가 |
+| `lib/calculator.ts` | calculateSpecialSupply 로직 수정 |
+| `app/calculator/page.tsx` | Step 5 UI — 혼인 날짜, 자녀 수 입력 추가 |
+| `app/result/page.tsx` | 특별공급 판정 근거 문구 추가 |
+
+## 복잡도
+
+**Medium** — 타입 변경이 여러 파일에 파급되므로 주의 필요

--- a/lib/calculator.ts
+++ b/lib/calculator.ts
@@ -91,27 +91,34 @@ export function calculateTotalScore(input: EligibilityInput): ScoreResult {
 }
 
 /**
+ * 혼인 기간 계산 (년 단위)
+ */
+export function calcMarriageYears(marriageDate: string): number {
+  if (!marriageDate) return Infinity;
+  const [year, month] = marriageDate.split('-').map(Number);
+  if (!year || !month) return Infinity;
+  const start = new Date(year, month - 1, 1);
+  return (new Date().getTime() - start.getTime()) / (1000 * 60 * 60 * 24 * 365.25);
+}
+
+/**
  * 특별공급 자격 판정
- * - 신혼부부: 혼인 상태이고 혼인 기간 7년 이내 (isMarried 활용)
- * - 생애최초: 무주택자이고 청약통장 가입
- * - 다자녀: 부양가족(미성년 자녀) 3명 이상
+ * - 신혼부부: 기혼 + 혼인 7년 이내
+ * - 생애최초: 무주택 + 청약통장 납입 12회 이상
+ * - 다자녀: 미성년(만 19세 미만) 자녀 3명 이상
  */
 export function calculateSpecialSupply(
   input: EligibilityInput,
 ): SpecialSupplyEligibility {
-  // 신혼부부: 혼인 상태
-  const newlyWed = input.isMarried;
+  // 신혼부부: 기혼 + 혼인 7년 이내
+  const newlyWed = input.isMarried && calcMarriageYears(input.marriageDate) <= 7;
 
   // 생애최초: 무주택 + 청약통장 납입 횟수 12회 이상
   const firstHome =
     input.isHomeless && input.subscriptionPaymentCount >= 12;
 
-  // 다자녀: 부양가족 3명 이상 (자녀 기준 - 간략화된 판정)
-  // 배우자 포함 부양가족 수에서 배우자 1명을 빼면 자녀 수로 간주
-  const childCount = input.isMarried
-    ? Math.max(0, input.dependentsCount - 1)
-    : input.dependentsCount;
-  const multiChild = childCount >= 3;
+  // 다자녀: 미성년(만 19세 미만) 자녀 3명 이상
+  const multiChild = (input.childrenCount ?? 0) >= 3;
 
   return { newlyWed, firstHome, multiChild };
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -17,6 +17,8 @@ export interface EligibilityInput {
 
   // 혼인/자녀
   isMarried: boolean;
+  marriageDate: string;    // YYYY-MM, 기혼일 때만 유효
+  childrenCount: number;   // 미성년(만 19세 미만) 자녀 수
   hasRecentChild: boolean; // 최근 2년 내 자녀 출산
 }
 


### PR DESCRIPTION
## Summary
- 신혼부부 특공: `isMarried` 단순 체크 → 기혼 + **혼인 7년 이내** 조건으로 정확화
- 다자녀 특공: 부양가족 수 추정 → **미성년 자녀 수 직접 입력** (`childrenCount`) 방식으로 변경
- Step 5 UI: 혼인 날짜 입력 필드(기혼일 때만 표시) + 실시간 혼인 기간 힌트 + 자녀 수 ± 버튼 추가
- 결과 페이지: 신혼부부/다자녀 카드에 판정 근거 문구 표시

## Test Plan
- [ ] Step 5에서 기혼 선택 시 혼인 날짜 필드 표시 확인
- [ ] 혼인 날짜 입력 시 실시간 힌트 (자격 있음/없음) 확인
- [ ] 미성년 자녀 수 ± 버튼 및 힌트 확인
- [ ] 혼인 7년 초과 → 신혼부부 특공 미해당 판정 확인
- [ ] 자녀 3명 이상 → 다자녀 특공 해당 판정 확인
- [ ] 결과 페이지 판정 근거 문구 표시 확인

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)