### PR TITLE
[Feature] 청약 D-Day 배지 UI 개선

### DIFF
--- a/app/announcements/[id]/page.tsx
+++ b/app/announcements/[id]/page.tsx
@@ -4,7 +4,7 @@ import { use, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import Disclaimer from '@/components/Disclaimer';
 import type { Announcement, StoredScoreData } from '@/types';
-import { getDday, getScoreTierLabel, getGeneralSupplyLabel, getSpecialSupplyLabels } from '@/lib/announcements';
+import { getDday, getDdayBadgeStyle, getScoreTierLabel, getGeneralSupplyLabel, getSpecialSupplyLabels } from '@/lib/announcements';
 
 export default function AnnouncementDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -45,7 +45,8 @@ export default function AnnouncementDetailPage({ params }: { params: Promise<{ i
   }
 
   const dday = getDday(announcement.subscriptionStartDate, announcement.subscriptionEndDate);
-  const ddayStyle =
+  const ddayBadge = getDdayBadgeStyle(dday);
+  const statusStyle =
     announcement.status === '접수중'
       ? 'bg-green-100 text-green-700'
       : announcement.status === '접수예정'
@@ -76,11 +77,18 @@ export default function AnnouncementDetailPage({ params }: { params: Promise<{ i
             <h1 className="text-xl font-bold text-gray-900 leading-snug flex-1">
               {announcement.complexName}
             </h1>
-            {announcement.status && (
-              <span className={`text-xs px-2.5 py-1 rounded-full font-semibold flex-shrink-0 ${ddayStyle}`}>
-                {announcement.status}
-              </span>
-            )}
+            <div className="flex items-center gap-1.5 flex-shrink-0">
+              {announcement.status && (
+                <span className={`text-xs px-2.5 py-1 rounded-full font-semibold ${statusStyle}`}>
+                  {announcement.status}
+                </span>
+              )}
+              {dday && dday !== '마감' && (
+                <span className={`text-xs px-2.5 py-1 rounded-full font-semibold ${ddayBadge.className}`}>
+                  {ddayBadge.label}
+                </span>
+              )}
+            </div>
           </div>
           <p className="text-sm text-gray-500">
             {announcement.builder} · {announcement.region} · {announcement.houseType}
@@ -108,9 +116,9 @@ export default function AnnouncementDetailPage({ params }: { params: Promise<{ i
                 <span className="text-gray-500">접수 마감</span>
                 <div className="flex items-center gap-2">
                   <span className="font-medium text-gray-800">{announcement.subscriptionEndDate}</span>
-                  {dday && (
-                    <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${ddayStyle}`}>
-                      {dday}
+                  {dday && dday !== '마감' && (
+                    <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${ddayBadge.className}`}>
+                      {ddayBadge.label}
                     </span>
                   )}
                 </div>

--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Disclaimer from '@/components/Disclaimer';
 import type { Announcement, StoredScoreData } from '@/types';
-import { getDday, getScoreTierLabel, getGeneralSupplyLabel, getSpecialSupplyLabels } from '@/lib/announcements';
+import { getDday, getDdayBadgeStyle, getScoreTierLabel, getGeneralSupplyLabel, getSpecialSupplyLabels } from '@/lib/announcements';
 
 const REGION_OPTIONS = [
   '전체',
@@ -280,6 +280,7 @@ function StatusBadge({ status }: { status: string | undefined }) {
 function AnnouncementCard({ announcement, scoreData }: { announcement: Announcement; scoreData: StoredScoreData | null }) {
   const router = useRouter();
   const dday = getDday(announcement.subscriptionStartDate, announcement.subscriptionEndDate);
+  const ddayBadge = getDdayBadgeStyle(dday);
 
   const handleCardClick = () => {
     try {
@@ -287,12 +288,6 @@ function AnnouncementCard({ announcement, scoreData }: { announcement: Announcem
     } catch {}
     router.push(`/announcements/${announcement.id}`);
   };
-  const ddayStyle =
-    announcement.status === '접수중'
-      ? 'text-green-600 font-bold'
-      : announcement.status === '접수예정'
-      ? 'text-blue-600 font-bold'
-      : 'text-gray-400';
 
   const tierLabel = scoreData ? getScoreTierLabel(scoreData.result.tier) : null;
   const generalSupply = scoreData ? getGeneralSupplyLabel(scoreData.input) : null;
@@ -308,7 +303,14 @@ function AnnouncementCard({ announcement, scoreData }: { announcement: Announcem
           <h3 className="font-bold text-gray-900 text-sm leading-snug flex-1">
             {announcement.complexName}
           </h3>
-          <StatusBadge status={announcement.status} />
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            <StatusBadge status={announcement.status} />
+            {dday && dday !== '마감' && (
+              <span className={`text-xs px-2 py-0.5 rounded-full font-semibold ${ddayBadge.className}`}>
+                {ddayBadge.label}
+              </span>
+            )}
+          </div>
         </div>
 
         <div className="space-y-1.5 text-xs text-gray-600">
@@ -337,9 +339,6 @@ function AnnouncementCard({ announcement, scoreData }: { announcement: Announcem
                 {announcement.subscriptionStartDate} ~{' '}
                 {announcement.subscriptionEndDate}
               </span>
-              {dday && (
-                <span className={`ml-auto text-xs ${ddayStyle}`}>{dday}</span>
-              )}
             </div>
           )}
         </div>

--- a/lib/announcements.ts
+++ b/lib/announcements.ts
@@ -158,6 +158,17 @@ export async function fetchAnnouncementsFromAPI(region?: string): Promise<Announ
   }
 }
 
+// D-Day 배지 스타일 (마감 임박도에 따른 색상 분기)
+export function getDdayBadgeStyle(dday: string): { label: string; className: string } {
+  if (!dday || dday === '마감') return { label: '마감', className: 'bg-gray-100 text-gray-400' };
+  if (dday === 'D-day') return { label: 'D-day', className: 'bg-red-500 text-white' };
+
+  const days = parseInt(dday.replace('D-', ''), 10);
+  if (days <= 3) return { label: dday, className: 'bg-red-100 text-red-600 font-bold' };
+  if (days <= 7) return { label: dday, className: 'bg-orange-100 text-orange-600 font-bold' };
+  return { label: dday, className: 'bg-blue-100 text-blue-600' };
+}
+
 // 등급 기반 추천 라벨
 export function getScoreTierLabel(tier: 'S' | 'A' | 'B' | 'C'): { text: string; style: string } {
   if (tier === 'S' || tier === 'A') {
@@ -199,9 +210,9 @@ export const MOCK_ANNOUNCEMENTS: Announcement[] = [
     complexName: '서울 강남 래미안 센트럴',
     builder: '삼성물산',
     region: '서울특별시',
-    announcementDate: '2026-02-10',
-    subscriptionStartDate: '2026-02-24',
-    subscriptionEndDate: '2026-02-26',
+    announcementDate: '2026-03-10',
+    subscriptionStartDate: '2026-03-22',
+    subscriptionEndDate: '2026-03-24',
     houseType: '민영주택',
     pdfUrl: 'https://www.applyhome.co.kr',
     totalHouseholds: 350,
@@ -212,9 +223,9 @@ export const MOCK_ANNOUNCEMENTS: Announcement[] = [
     complexName: '경기 판교 힐스테이트',
     builder: '현대엔지니어링',
     region: '경기도',
-    announcementDate: '2026-02-12',
-    subscriptionStartDate: '2026-02-28',
-    subscriptionEndDate: '2026-03-04',
+    announcementDate: '2026-03-12',
+    subscriptionStartDate: '2026-03-21',
+    subscriptionEndDate: '2026-03-25',
     houseType: '민영주택',
     pdfUrl: 'https://www.applyhome.co.kr',
     totalHouseholds: 520,
@@ -225,9 +236,9 @@ export const MOCK_ANNOUNCEMENTS: Announcement[] = [
     complexName: '부산 해운대 더샵 마리나',
     builder: '포스코이앤씨',
     region: '부산광역시',
-    announcementDate: '2026-02-14',
-    subscriptionStartDate: '2026-03-03',
-    subscriptionEndDate: '2026-03-05',
+    announcementDate: '2026-03-14',
+    subscriptionStartDate: '2026-03-21',
+    subscriptionEndDate: '2026-03-23',
     houseType: '민영주택',
     pdfUrl: 'https://www.applyhome.co.kr',
     totalHouseholds: 280,
@@ -238,9 +249,9 @@ export const MOCK_ANNOUNCEMENTS: Announcement[] = [
     complexName: '인천 송도 자이 더 스타',
     builder: 'GS건설',
     region: '인천광역시',
-    announcementDate: '2026-02-17',
-    subscriptionStartDate: '2026-03-10',
-    subscriptionEndDate: '2026-03-12',
+    announcementDate: '2026-03-15',
+    subscriptionStartDate: '2026-03-26',
+    subscriptionEndDate: '2026-03-28',
     houseType: '민영주택',
     pdfUrl: 'https://www.applyhome.co.kr',
     totalHouseholds: 410,
@@ -251,9 +262,9 @@ export const MOCK_ANNOUNCEMENTS: Announcement[] = [
     complexName: '대구 수성 e편한세상',
     builder: 'DL이앤씨',
     region: '대구광역시',
-    announcementDate: '2026-02-18',
-    subscriptionStartDate: '2026-03-17',
-    subscriptionEndDate: '2026-03-19',
+    announcementDate: '2026-03-16',
+    subscriptionStartDate: '2026-03-28',
+    subscriptionEndDate: '2026-03-30',
     houseType: '민영주택',
     pdfUrl: 'https://www.applyhome.co.kr',
     totalHouseholds: 195,
@@ -264,9 +275,9 @@ export const MOCK_ANNOUNCEMENTS: Announcement[] = [
     complexName: '경기 의정부 한양수자인',
     builder: '한양',
     region: '경기도',
-    announcementDate: '2026-02-19',
-    subscriptionStartDate: '2026-03-24',
-    subscriptionEndDate: '2026-03-26',
+    announcementDate: '2026-03-17',
+    subscriptionStartDate: '2026-04-01',
+    subscriptionEndDate: '2026-04-03',
     houseType: '민영주택',
     pdfUrl: 'https://www.applyhome.co.kr',
     totalHouseholds: 320,
@@ -277,9 +288,9 @@ export const MOCK_ANNOUNCEMENTS: Announcement[] = [
     complexName: '세종 행복도시 국민임대',
     builder: 'LH한국토지주택공사',
     region: '세종특별자치시',
-    announcementDate: '2026-02-20',
-    subscriptionStartDate: '2026-03-04',
-    subscriptionEndDate: '2026-03-06',
+    announcementDate: '2026-03-18',
+    subscriptionStartDate: '2026-04-07',
+    subscriptionEndDate: '2026-04-09',
     houseType: '공공임대',
     pdfUrl: 'https://www.applyhome.co.kr',
     totalHouseholds: 150,
@@ -290,9 +301,9 @@ export const MOCK_ANNOUNCEMENTS: Announcement[] = [
     complexName: '광주 첨단 아이파크',
     builder: 'HDC현대산업개발',
     region: '광주광역시',
-    announcementDate: '2026-02-21',
-    subscriptionStartDate: '2026-03-18',
-    subscriptionEndDate: '2026-03-20',
+    announcementDate: '2026-03-19',
+    subscriptionStartDate: '2026-04-14',
+    subscriptionEndDate: '2026-04-16',
     houseType: '민영주택',
     pdfUrl: 'https://www.applyhome.co.kr',
     totalHouseholds: 240,


### PR DESCRIPTION
- getDdayBadgeStyle() 함수 추가: 마감 임박도에 따른 색상 분기
  - D-day: 빨강(solid), D-1~3: 빨강, D-4~7: 주황, D-8+: 파랑
- AnnouncementCard 헤더에 pill 형태의 D-Day 배지 표시 (상태 배지 옆)
- 공고 상세 페이지 헤더 및 청약 일정 섹션에 동일 배지 스타일 적용
- Mock 데이터 날짜를 2026-03-21 기준 미래 날짜로 업데이트

https://claude.ai/code/session_01GpSVNkeBXJuGMqc8fh3LD3