### PR TITLE
[#35] fix: 만 30세 미만 미혼 무주택기간 0점 처리

### DIFF
--- a/lib/calculator.ts
+++ b/lib/calculator.ts
@@ -111,9 +111,14 @@ export function calculateSubscriptionScore(startDate: string): number {
  * 총점 = 무주택(0~32) + 부양가족(0~35) + 청약통장(0~17) = 0~84점
  */
 export function calculateTotalScore(input: EligibilityInput): ScoreResult {
-  const homelessScore = input.isHomeless
-    ? calculateHomelessScore(input.homelessYears)
-    : 0;
+  let homelessScore = 0;
+  if (input.isHomeless) {
+    // 만 30세 미만 미혼은 산정 불가 → 0점 (정책: 주택공급에관한규칙)
+    const startDate = calcHomelessStartDate(input.birthDate, input.isMarried, input.marriageDate);
+    if (startDate !== null) {
+      homelessScore = calculateHomelessScore(input.homelessYears);
+    }
+  }
   const dependentsScore = calculateDependentsScore(input.dependentsCount);
   const subscriptionScore = calculateSubscriptionScore(input.subscriptionStartDate);
   const totalScore = homelessScore + dependentsScore + subscriptionScore;


### PR DESCRIPTION
## Summary
- 만 30세 미만 미혼 케이스에서 무주택기간 점수가 2점으로 잘못 계산되던 버그 수정
- `calcHomelessStartDate`가 null(산정 불가)인 경우 `calculateHomelessScore` 호출 없이 0점 처리
- 정책 기준: 주택공급에관한규칙 — 만 30세 미만 미혼은 무주택기간 산정 불가

## Root Cause
`calculateHomelessScore(0)`이 항상 최소 2점을 반환하도록 구현되어 있었으나,
만 30세 미만 미혼(산정 불가)과 만 30세 이상(0년 이상 경과)을 구분하지 못함.

## Fix
`calculateTotalScore`에서 `calcHomelessStartDate` null 체크 추가:
- `startDate === null` → 0점 (산정 불가)
- `startDate !== null` → 기존 로직 유지

## Test plan
- [ ] 만 30세 미만 미혼 → 무주택기간 점수 0점 확인
- [ ] 만 30세 이상 미혼 → 정상 점수 계산 확인
- [ ] 기혼 + 만 30세 미만 → 혼인신고일 기준 점수 계산 확인
- [ ] 빌드 통과 확인

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)