### PR TITLE
[#57] feat: 모바일 UI 반응형 개선

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -10,6 +10,8 @@ import type { AnnouncementDetail } from '@/types';
 import { useFavorites } from '@/hooks/useFavorites';
 import type { SessionUser } from '@/types/auth';
 import { calculateTotalScore, calculateSpecialSupply } from '@/lib/calculator';
+import Tooltip from '@/components/Tooltip';
+import { TERM_MAP } from '@/lib/terms';
 
 const REGION_OPTIONS = [
   '전체',
@@ -216,8 +218,8 @@ export default function AnnouncementsPage() {
 
         {/* Score Summary Bar */}
         {scoreData && (
-          <div className="flex items-center justify-between bg-blue-50 border border-blue-200 rounded-xl px-4 py-3 mb-4">
-            <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2 bg-blue-50 border border-blue-200 rounded-xl px-4 py-3 mb-4">
+            <div className="flex items-center gap-2 flex-wrap">
               <span className="text-sm text-gray-600">내 가점</span>
               <span className="text-lg font-bold text-blue-700">{scoreData.result.totalScore}점</span>
               <span className="text-xs text-gray-500">/ 84점</span>
@@ -264,12 +266,12 @@ export default function AnnouncementsPage() {
               </button>
             </div>
           </div>
-          <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+          <div className="flex flex-wrap gap-2">
             {REGION_OPTIONS.map((region) => (
               <button
                 key={region}
                 onClick={() => setSelectedRegion(region)}
-                className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
+                className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
                   selectedRegion === region
                     ? 'bg-blue-600 text-white shadow-sm'
                     : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
@@ -434,28 +436,28 @@ function AnnouncementCard({
         </div>
 
         <div className="space-y-1.5 text-xs text-gray-600">
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2">
             <span className="text-gray-400 w-14 flex-shrink-0">건설사</span>
-            <span className="font-medium">{announcement.builder}</span>
+            <span className="font-medium min-w-0 break-words">{announcement.builder}</span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2">
             <span className="text-gray-400 w-14 flex-shrink-0">지역</span>
-            <span>{announcement.region}</span>
+            <span className="min-w-0 break-words">{announcement.region}</span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2">
             <span className="text-gray-400 w-14 flex-shrink-0">유형</span>
-            <span>{announcement.houseType}</span>
+            <span className="min-w-0 break-words">{announcement.houseType}</span>
           </div>
           {announcement.totalHouseholds !== undefined && (
-            <div className="flex items-center gap-2">
+            <div className="flex items-start gap-2">
               <span className="text-gray-400 w-14 flex-shrink-0">세대수</span>
               <span>{announcement.totalHouseholds.toLocaleString()}세대</span>
             </div>
           )}
           {announcement.subscriptionStartDate && (
-            <div className="flex items-center gap-2">
+            <div className="flex items-start gap-2">
               <span className="text-gray-400 w-14 flex-shrink-0">접수기간</span>
-              <span>
+              <span className="min-w-0 break-words">
                 {announcement.subscriptionStartDate} ~{' '}
                 {announcement.subscriptionEndDate}
               </span>
@@ -634,25 +636,16 @@ function AnnouncementDetail({ announcement, scoreData }: { announcement: Announc
           {detail.units.length > 0 && (
             <div className="mb-4">
               <SectionLabel>주택형별 공급</SectionLabel>
-              <div className="mt-3 rounded-xl overflow-hidden border border-gray-100">
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="text-left px-3 py-2 text-gray-500 font-semibold">주택형</th>
-                      <th className="text-right px-3 py-2 text-gray-500 font-semibold">세대수</th>
-                      <th className="text-right px-3 py-2 text-gray-500 font-semibold">분양가(만원)</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-50">
-                    {detail.units.map((u, i) => (
-                      <tr key={i} className="bg-white">
-                        <td className="px-3 py-2.5 text-gray-800 font-medium">{u.type}</td>
-                        <td className="px-3 py-2.5 text-gray-700 text-right">{u.totalCount || '-'}</td>
-                        <td className="px-3 py-2.5 text-gray-700 text-right">{u.price || '-'}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+              <div className="mt-3 space-y-2">
+                {detail.units.map((u, i) => (
+                  <div key={i} className="rounded-xl border border-gray-100 bg-white px-3 py-2.5">
+                    <p className="text-xs font-semibold text-gray-800 mb-1">{u.type}</p>
+                    <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-gray-600">
+                      <span>세대수 <span className="font-medium text-gray-800">{u.totalCount || '-'}</span></span>
+                      <span>분양가 <span className="font-medium text-gray-800">{u.price ? `${u.price}만원` : '-'}</span></span>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -172,8 +172,12 @@ export default async function HomePage() {
               <span className="text-2xl font-bold text-blue-700">{latestScore.totalScore}점</span>
               <span className="text-xs text-gray-400">{new Date(latestScore.createdAt).toLocaleDateString('ko-KR')}</span>
             </div>
-            <div className="text-xs text-gray-500 mt-1">
-              무주택 {latestScore.housingScore}점 · 부양가족 {latestScore.dependentScore}점 · 청약통장 {latestScore.subscriptionScore}점
+            <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-xs text-gray-500 mt-1">
+              <span>무주택 {latestScore.housingScore}점</span>
+              <span>·</span>
+              <span>부양가족 {latestScore.dependentScore}점</span>
+              <span>·</span>
+              <span>청약통장 {latestScore.subscriptionScore}점</span>
             </div>
           </div>
         )}

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -321,7 +321,7 @@ function SpecialBadge({
 }) {
   return (
     <div
-      className={`flex items-center justify-between p-3 rounded-xl ${
+      className={`flex items-start justify-between gap-2 p-3 rounded-xl ${
         eligible ? 'bg-green-50 border border-green-200' : 'bg-gray-50 border border-gray-200'
       }`}
     >


### PR DESCRIPTION
## Summary
- 지역 필터: 수평 스크롤 → `flex-wrap` 으로 전체 지역 한 눈에 파악 가능
- 공고 카드: `items-start` + `min-w-0 break-words` 로 긴 건설사명/지역명 overflow 방지
- 주택형 테이블: 3열 `<table>` → 카드 리스트로 교체 (모바일 가독성)
- 점수 요약 바: `flex-wrap` 으로 좁은 화면에서 버튼 겹침 방지
- 특별공급 배지: `items-start` 로 긴 설명 텍스트 줄바꿈 처리
- 홈 점수 카드: `flex-wrap` 으로 점수 항목 줄바꿈 처리

## Test plan
- [ ] 360px 폭 화면에서 지역 필터 버튼 wrap 확인
- [ ] 긴 건설사명 공고 카드에서 텍스트 잘림 없음 확인
- [ ] 주택형 카드 리스트 가독성 확인
- [ ] 홈 이전 점수 카드 좁은 화면에서 줄바꿈 확인

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)