### PR TITLE
[#59] feat: PWA manifest 및 스토어 배포 기반 구성

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -10,6 +10,8 @@ import type { AnnouncementDetail } from '@/types';
 import { useFavorites } from '@/hooks/useFavorites';
 import type { SessionUser } from '@/types/auth';
 import { calculateTotalScore, calculateSpecialSupply } from '@/lib/calculator';
+import Tooltip from '@/components/Tooltip';
+import { TERM_MAP } from '@/lib/terms';
 
 const REGION_OPTIONS = [
   '전체',
@@ -216,8 +218,8 @@ export default function AnnouncementsPage() {
 
         {/* Score Summary Bar */}
         {scoreData && (
-          <div className="flex items-center justify-between bg-blue-50 border border-blue-200 rounded-xl px-4 py-3 mb-4">
-            <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center justify-between gap-2 bg-blue-50 border border-blue-200 rounded-xl px-4 py-3 mb-4">
+            <div className="flex items-center gap-2 flex-wrap">
               <span className="text-sm text-gray-600">내 가점</span>
               <span className="text-lg font-bold text-blue-700">{scoreData.result.totalScore}점</span>
               <span className="text-xs text-gray-500">/ 84점</span>
@@ -264,12 +266,12 @@ export default function AnnouncementsPage() {
               </button>
             </div>
           </div>
-          <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide">
+          <div className="flex flex-wrap gap-2">
             {REGION_OPTIONS.map((region) => (
               <button
                 key={region}
                 onClick={() => setSelectedRegion(region)}
-                className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
+                className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
                   selectedRegion === region
                     ? 'bg-blue-600 text-white shadow-sm'
                     : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
@@ -434,28 +436,28 @@ function AnnouncementCard({
         </div>
 
         <div className="space-y-1.5 text-xs text-gray-600">
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2">
             <span className="text-gray-400 w-14 flex-shrink-0">건설사</span>
-            <span className="font-medium">{announcement.builder}</span>
+            <span className="font-medium min-w-0 break-words">{announcement.builder}</span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2">
             <span className="text-gray-400 w-14 flex-shrink-0">지역</span>
-            <span>{announcement.region}</span>
+            <span className="min-w-0 break-words">{announcement.region}</span>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2">
             <span className="text-gray-400 w-14 flex-shrink-0">유형</span>
-            <span>{announcement.houseType}</span>
+            <span className="min-w-0 break-words">{announcement.houseType}</span>
           </div>
           {announcement.totalHouseholds !== undefined && (
-            <div className="flex items-center gap-2">
+            <div className="flex items-start gap-2">
               <span className="text-gray-400 w-14 flex-shrink-0">세대수</span>
               <span>{announcement.totalHouseholds.toLocaleString()}세대</span>
             </div>
           )}
           {announcement.subscriptionStartDate && (
-            <div className="flex items-center gap-2">
+            <div className="flex items-start gap-2">
               <span className="text-gray-400 w-14 flex-shrink-0">접수기간</span>
-              <span>
+              <span className="min-w-0 break-words">
                 {announcement.subscriptionStartDate} ~{' '}
                 {announcement.subscriptionEndDate}
               </span>
@@ -634,25 +636,16 @@ function AnnouncementDetail({ announcement, scoreData }: { announcement: Announc
           {detail.units.length > 0 && (
             <div className="mb-4">
               <SectionLabel>주택형별 공급</SectionLabel>
-              <div className="mt-3 rounded-xl overflow-hidden border border-gray-100">
-                <table className="w-full text-xs">
-                  <thead className="bg-gray-50">
-                    <tr>
-                      <th className="text-left px-3 py-2 text-gray-500 font-semibold">주택형</th>
-                      <th className="text-right px-3 py-2 text-gray-500 font-semibold">세대수</th>
-                      <th className="text-right px-3 py-2 text-gray-500 font-semibold">분양가(만원)</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-gray-50">
-                    {detail.units.map((u, i) => (
-                      <tr key={i} className="bg-white">
-                        <td className="px-3 py-2.5 text-gray-800 font-medium">{u.type}</td>
-                        <td className="px-3 py-2.5 text-gray-700 text-right">{u.totalCount || '-'}</td>
-                        <td className="px-3 py-2.5 text-gray-700 text-right">{u.price || '-'}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+              <div className="mt-3 space-y-2">
+                {detail.units.map((u, i) => (
+                  <div key={i} className="rounded-xl border border-gray-100 bg-white px-3 py-2.5">
+                    <p className="text-xs font-semibold text-gray-800 mb-1">{u.type}</p>
+                    <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-gray-600">
+                      <span>세대수 <span className="font-medium text-gray-800">{u.totalCount || '-'}</span></span>
+                      <span>분양가 <span className="font-medium text-gray-800">{u.price ? `${u.price}만원` : '-'}</span></span>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
           )}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,6 +17,17 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "청약 매칭 가이드",
   description: "나에게 맞는 청약을 쉽게 찾아보세요",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'black-translucent',
+    title: '청약 가이드',
+  },
+  formatDetection: {
+    telephone: false,
+  },
+  other: {
+    'mobile-web-app-capable': 'yes',
+  },
 };
 
 export default function RootLayout({

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,75 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: '청약 매칭 가이드',
+    short_name: '청약 가이드',
+    description: '복잡한 청약 가점을 자동으로 계산하고, 내 상황에 맞는 청약 공고를 추천해 드립니다.',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    orientation: 'portrait-primary',
+    background_color: '#ffffff',
+    theme_color: '#2563eb',
+    lang: 'ko',
+    categories: ['finance', 'productivity', 'utilities'],
+    icons: [
+      {
+        src: '/icons/icon-192x192.png',
+        sizes: '192x192',
+        type: 'image/png',
+        purpose: 'any',
+      },
+      {
+        src: '/icons/icon-192x192-maskable.png',
+        sizes: '192x192',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+      {
+        src: '/icons/icon-512x512.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'any',
+      },
+      {
+        src: '/icons/icon-512x512-maskable.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+    ],
+    shortcuts: [
+      {
+        name: '가점 계산하기',
+        short_name: '가점 계산',
+        description: '청약 가점을 바로 계산합니다',
+        url: '/calculator',
+        icons: [{ src: '/icons/icon-96x96.png', sizes: '96x96' }],
+      },
+      {
+        name: '청약 공고 보기',
+        short_name: '공고 보기',
+        description: '최신 청약 공고를 확인합니다',
+        url: '/announcements',
+        icons: [{ src: '/icons/icon-96x96.png', sizes: '96x96' }],
+      },
+    ],
+    screenshots: [
+      {
+        src: '/screenshots/screenshot-home.png',
+        sizes: '390x844',
+        type: 'image/png',
+        form_factor: 'narrow',
+        label: '홈 화면',
+      },
+      {
+        src: '/screenshots/screenshot-calculator.png',
+        sizes: '390x844',
+        type: 'image/png',
+        form_factor: 'narrow',
+        label: '가점 계산기',
+      },
+    ],
+  };
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -172,8 +172,12 @@ export default async function HomePage() {
               <span className="text-2xl font-bold text-blue-700">{latestScore.totalScore}점</span>
               <span className="text-xs text-gray-400">{new Date(latestScore.createdAt).toLocaleDateString('ko-KR')}</span>
             </div>
-            <div className="text-xs text-gray-500 mt-1">
-              무주택 {latestScore.housingScore}점 · 부양가족 {latestScore.dependentScore}점 · 청약통장 {latestScore.subscriptionScore}점
+            <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-xs text-gray-500 mt-1">
+              <span>무주택 {latestScore.housingScore}점</span>
+              <span>·</span>
+              <span>부양가족 {latestScore.dependentScore}점</span>
+              <span>·</span>
+              <span>청약통장 {latestScore.subscriptionScore}점</span>
             </div>
           </div>
         )}

--- a/app/result/page.tsx
+++ b/app/result/page.tsx
@@ -321,7 +321,7 @@ function SpecialBadge({
 }) {
   return (
     <div
-      className={`flex items-center justify-between p-3 rounded-xl ${
+      className={`flex items-start justify-between gap-2 p-3 rounded-xl ${
         eligible ? 'bg-green-50 border border-green-200' : 'bg-gray-50 border border-gray-200'
       }`}
     >

--- a/docs/technical/mobile-deployment-strategy.md
+++ b/docs/technical/mobile-deployment-strategy.md
@@ -1,0 +1,163 @@
+# 모바일 앱 배포 전략 (Android / iOS)
+
+> 관련 이슈: #59
+
+---
+
+## 현재 상태 분석
+
+| 항목 | 현재 설정 | 모바일 배포 시 필요한 변경 |
+|------|----------|--------------------------|
+| `next.config.ts` | `output: "standalone"` | `output: "export"` 로 변경 필요 |
+| API Routes | `app/api/` (4개: announcements, auth, favorites, scores) | 제거 후 클라이언트 직접 호출로 대체 |
+| 인증 | Kakao OAuth (서버 사이드 세션) | 클라이언트 사이드 인증으로 전환 필요 |
+| DB | Supabase + Drizzle ORM (서버에서 호출) | Supabase 클라이언트 SDK 직접 사용 |
+
+---
+
+## 배포 방식 비교
+
+### Option A — PWA (Progressive Web App)
+
+**적합성: 낮음**
+
+- 홈 화면에 설치 가능하지만 앱스토어 배포 불가
+- iOS에서 푸시 알림 불가, 기기 API 제한적
+- API Routes 유지 가능 (서버 필요)
+- 코드 변경 최소 (manifest.json + service worker 추가)
+
+**장점:** 빠른 구현 (1~2일), 코드 변경 없음
+**단점:** 앱스토어 배포 불가, iOS 기능 제한
+
+---
+
+### Option B — Capacitor (권장)
+
+**적합성: 높음**
+
+Ionic의 Capacitor는 기존 웹 앱을 WebView로 감싸 네이티브 앱으로 빌드한다.
+App Router + Static Export와 호환되며, 앱스토어 정식 배포 가능.
+
+**흐름:**
+```
+Next.js Build (output: export) → out/ 폴더
+  → Capacitor Sync → iOS 프로젝트 (Xcode)
+                   → Android 프로젝트 (Android Studio)
+  → 앱스토어 배포
+```
+
+**장점:** 앱스토어 배포 가능, 기기 API 접근, 기존 코드 최대 재사용
+**단점:** API Routes 제거 필요, 빌드 환경 구성 필요 (Xcode 등)
+
+---
+
+## 권장 방향: Capacitor + Static Export
+
+### 핵심 제약사항
+
+`output: "export"` 전환 시 아래 기능이 동작하지 않는다:
+
+| 기능 | 현재 | 정적 export 시 |
+|------|------|----------------|
+| `app/api/announcements` | ✅ | ❌ (API 라우트 불가) |
+| `app/api/auth` (Kakao OAuth) | ✅ | ❌ (서버 세션 불가) |
+| `app/api/favorites` | ✅ | ❌ |
+| `app/api/scores` | ✅ | ❌ |
+
+### API Routes 대체 방안
+
+| 현재 API | 대체 방안 |
+|----------|----------|
+| `/api/announcements` | 한국부동산원 API 직접 클라이언트 호출 또는 Supabase Edge Function |
+| `/api/auth/kakao` | Supabase Auth (Kakao provider 지원) 또는 Kakao JS SDK |
+| `/api/favorites` | Supabase 클라이언트 SDK 직접 호출 |
+| `/api/scores` | Supabase 클라이언트 SDK 직접 호출 |
+
+### 인증 전환 방안
+
+현재 Kakao OAuth는 서버 사이드 세션 기반. 두 가지 옵션:
+
+**옵션 1 — Supabase Auth + Kakao Provider**
+- Supabase에서 Kakao OAuth provider 설정
+- `@supabase/supabase-js` 클라이언트에서 `signInWithOAuth({ provider: 'kakao' })` 호출
+- 세션은 Supabase JWT로 관리 (클라이언트 저장)
+
+**옵션 2 — Kakao JavaScript SDK**
+- 카카오 JS SDK를 직접 사용
+- 토큰을 클라이언트에 저장 후 Supabase에 custom JWT로 연동
+
+→ **Supabase Auth + Kakao Provider 권장** (관리 편의성)
+
+---
+
+## 구현 로드맵
+
+### Phase 1: 사전 검증 (1주)
+- [ ] `output: "export"` 로 전환 후 빌드 오류 목록 파악
+- [ ] API Routes 중 Supabase 직접 호출 가능 여부 확인 (favorites, scores)
+- [ ] Kakao OAuth → Supabase Auth 전환 PoC
+
+### Phase 2: API 마이그레이션 (1~2주)
+- [ ] `app/api/favorites` → `@supabase/supabase-js` 직접 호출
+- [ ] `app/api/scores` → Supabase 직접 호출
+- [ ] `app/api/announcements` → 외부 API 직접 호출 or Supabase Edge Function
+- [ ] `app/api/auth` → Supabase Auth + Kakao provider
+
+### Phase 3: Capacitor 통합 (1주)
+```bash
+npm install @capacitor/core @capacitor/cli
+npx cap init "청약매칭가이드" "com.blue.cheongyak"
+npm install @capacitor/ios @capacitor/android
+npx cap add ios
+npx cap add android
+```
+- `next.config.ts` 수정:
+  ```ts
+  const nextConfig = {
+    output: "export",
+    images: { unoptimized: true },
+  };
+  ```
+- `npx cap sync` 로 정적 빌드 동기화
+
+### Phase 4: 앱스토어 배포 준비 (1~2주)
+- [ ] 앱 아이콘 / 스플래시 스크린 제작
+- [ ] iOS: Apple Developer Program ($99/년) 가입 + Xcode 빌드
+- [ ] Android: Google Play Console ($25 일회성) 가입 + Android Studio 빌드
+- [ ] 앱 심사 제출
+
+---
+
+## 예상 일정
+
+| 단계 | 기간 |
+|------|------|
+| Phase 1: 사전 검증 | 1주 |
+| Phase 2: API 마이그레이션 | 1~2주 |
+| Phase 3: Capacitor 통합 | 1주 |
+| Phase 4: 앱스토어 배포 | 1~2주 |
+| **총 합계** | **4~6주** |
+
+---
+
+## 빠른 시작: PWA (단기 옵션)
+
+앱스토어 배포가 급하지 않고 모바일 사용성을 빠르게 개선하고 싶다면 PWA를 먼저 적용 가능.
+
+**구현 소요: 1~2일**
+
+1. `app/manifest.ts` 추가
+2. `public/` 에 앱 아이콘 추가
+3. `app/layout.tsx` 에 메타데이터 추가
+4. (선택) `Serwist` 라이브러리로 서비스 워커 추가
+
+PWA 적용 후 → Capacitor 마이그레이션 순서로 진행하는 것도 가능.
+
+---
+
+## 참고
+
+- [Capacitor 공식 문서](https://capacitorjs.com/)
+- [Next.js Static Exports](https://nextjs.org/docs/app/guides/static-exports)
+- [Supabase Auth - Kakao Provider](https://supabase.com/docs/guides/auth/social-login/auth-kakao)
+- [Next.js PWA (Serwist)](https://serwist.pages.dev/)

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.blue.cheongyak",
+      "sha256_cert_fingerprints": [
+        "REPLACE_WITH_SHA256_FROM_PLAY_CONSOLE"
+      ]
+    }
+  }
+]

--- a/public/icons/README.md
+++ b/public/icons/README.md
@@ -1,0 +1,33 @@
+# 앱 아이콘 가이드
+
+PWABuilder 제출 및 스토어 배포를 위해 아래 아이콘 파일이 필요합니다.
+
+## 필수 아이콘 목록
+
+| 파일명 | 크기 | 용도 |
+|--------|------|------|
+| `icon-96x96.png` | 96×96 | 숏컷 아이콘 |
+| `icon-192x192.png` | 192×192 | Android 홈 화면 |
+| `icon-192x192-maskable.png` | 192×192 | Android Adaptive Icon (safe zone 준수) |
+| `icon-512x512.png` | 512×512 | Play Store / PWABuilder 기본 |
+| `icon-512x512-maskable.png` | 512×512 | 고해상도 Adaptive Icon |
+
+## Apple용 추가 아이콘 (App Store)
+
+| 파일명 | 크기 | 용도 |
+|--------|------|------|
+| `apple-touch-icon.png` | 180×180 | iOS 홈 화면 (public/ 루트에 위치) |
+
+## 제작 가이드
+
+- **Maskable 아이콘**: 전체 이미지 영역의 80% 안에 핵심 로고를 배치 (safe zone)
+- **배경색**: `#2563eb` (파란색) 권장
+- **포맷**: PNG (투명 배경 사용 가능, maskable는 불가)
+- **도구**: [Maskable.app](https://maskable.app/) 에서 maskable 아이콘 미리보기 가능
+
+## 스크린샷 (public/screenshots/)
+
+| 파일명 | 크기 | 용도 |
+|--------|------|------|
+| `screenshot-home.png` | 390×844 | 홈 화면 (iPhone 14 기준) |
+| `screenshot-calculator.png` | 390×844 | 가점 계산기 화면 |

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,26 @@
+{
+  "headers": [
+    {
+      "source": "/.well-known/(.*)",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "/manifest.webmanifest",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/manifest+json"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 개요
현재 Next.js 구조를 유지하면서 Android Play Store / iOS App Store 배포를 위한 PWA 기반을 구성합니다.

## 변경 사항

### 추가 파일
- `app/manifest.ts` — Web App Manifest (이름, 아이콘, 숏컷, 스크린샷)
- `public/.well-known/assetlinks.json` — Android TWA Digital Asset Links 템플릿
- `public/icons/README.md` — 필요한 아이콘 파일 제작 가이드
- `vercel.json` — `.well-known`, `/manifest.webmanifest` Content-Type 헤더
- `docs/technical/mobile-deployment-strategy.md` — 모바일 배포 전략 문서

### 수정 파일
- `app/layout.tsx` — Apple PWA 메타 태그 추가

## 배포 다음 단계 (PR 머지 후)

### 아이콘 제작 (필수)
public/icons/README.md 가이드 참고하여 아래 파일 준비:
- icon-96x96.png, icon-192x192.png, icon-192x192-maskable.png
- icon-512x512.png, icon-512x512-maskable.png
- apple-touch-icon.png (public/ 루트)

### Android (Play Store)
1. Vercel 배포 후 manifest.webmanifest 확인
2. pwabuilder.com에서 URL 입력 → Android 패키지 다운로드
3. Play Console SHA-256 지문 → assetlinks.json 업데이트
4. Play Store 제출

### iOS (App Store)
1. pwabuilder.com에서 iOS 패키지 다운로드 (Xcode 프로젝트)
2. 스토어 승인율 향상을 위해 Push Notification 추가 권장
3. App Store Connect 제출

Closes #59