### PR TITLE
feat: 카카오 로그인 후 약관 동의 플로우 추가

### DIFF
--- a/app/agree/page.tsx
+++ b/app/agree/page.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function AgreePage() {
+  const router = useRouter();
+  const [allAgreed, setAllAgreed] = useState(false);
+  const [termsAgreed, setTermsAgreed] = useState(false);
+  const [privacyAgreed, setPrivacyAgreed] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleAllAgree = (checked: boolean) => {
+    setAllAgreed(checked);
+    setTermsAgreed(checked);
+    setPrivacyAgreed(checked);
+  };
+
+  const handleIndividual = (type: 'terms' | 'privacy', checked: boolean) => {
+    if (type === 'terms') setTermsAgreed(checked);
+    if (type === 'privacy') setPrivacyAgreed(checked);
+    setAllAgreed(checked && (type === 'terms' ? privacyAgreed : termsAgreed));
+  };
+
+  const canProceed = termsAgreed && privacyAgreed;
+
+  const handleAgree = async () => {
+    if (!canProceed || loading) return;
+    setLoading(true);
+    await fetch('/api/auth/agree?redirect=/', { method: 'POST' });
+    router.replace('/');
+  };
+
+  return (
+    <main className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        {/* 헤더 */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-14 h-14 bg-blue-600 rounded-2xl mb-4 shadow-lg">
+            <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+          <h1 className="text-xl font-bold text-gray-900">서비스 이용 동의</h1>
+          <p className="text-sm text-gray-500 mt-1">청약 매칭 가이드를 이용하시려면<br />아래 약관에 동의해 주세요.</p>
+        </div>
+
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-4">
+          {/* 전체 동의 */}
+          <label className="flex items-center gap-3 px-5 py-4 cursor-pointer bg-blue-50 border-b border-blue-100">
+            <input
+              type="checkbox"
+              checked={allAgreed}
+              onChange={(e) => handleAllAgree(e.target.checked)}
+              className="w-5 h-5 accent-blue-600 rounded"
+            />
+            <span className="font-bold text-blue-700 text-sm">전체 동의</span>
+          </label>
+
+          {/* 이용약관 */}
+          <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-100">
+            <label className="flex items-center gap-3 flex-1 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={termsAgreed}
+                onChange={(e) => handleIndividual('terms', e.target.checked)}
+                className="w-4 h-4 accent-blue-600"
+              />
+              <span className="text-sm text-gray-700">
+                <span className="text-blue-600 font-medium">[필수]</span> 이용약관 동의
+              </span>
+            </label>
+            <Link href="/terms" target="_blank" className="text-xs text-gray-400 hover:text-gray-600 flex-shrink-0">
+              보기
+            </Link>
+          </div>
+
+          {/* 개인정보 처리방침 */}
+          <div className="flex items-center gap-3 px-5 py-4">
+            <label className="flex items-center gap-3 flex-1 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={privacyAgreed}
+                onChange={(e) => handleIndividual('privacy', e.target.checked)}
+                className="w-4 h-4 accent-blue-600"
+              />
+              <span className="text-sm text-gray-700">
+                <span className="text-blue-600 font-medium">[필수]</span> 개인정보 처리방침 동의
+              </span>
+            </label>
+            <Link href="/privacy" target="_blank" className="text-xs text-gray-400 hover:text-gray-600 flex-shrink-0">
+              보기
+            </Link>
+          </div>
+        </div>
+
+        {/* 면책 안내 */}
+        <p className="text-xs text-gray-400 text-center mb-6 px-2 leading-relaxed">
+          본 서비스는 참고용 가이드이며 공식 청약 자격 판정이 아닙니다.<br />
+          실제 청약은 청약홈에서 반드시 확인하세요.
+        </p>
+
+        {/* 동의 버튼 */}
+        <button
+          onClick={handleAgree}
+          disabled={!canProceed || loading}
+          className={`w-full py-4 rounded-xl font-bold text-base transition-all ${
+            canProceed
+              ? 'bg-blue-600 hover:bg-blue-700 text-white shadow-md'
+              : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+          }`}
+        >
+          {loading ? '처리 중...' : '동의하고 시작하기'}
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/app/api/auth/agree/route.ts
+++ b/app/api/auth/agree/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const TERMS_AGREED_COOKIE = 'blue_terms_agreed';
+const ONE_YEAR = 60 * 60 * 24 * 365;
+
+export async function POST(request: NextRequest) {
+  const redirectTo = request.nextUrl.searchParams.get('redirect') ?? '/';
+
+  const response = NextResponse.redirect(new URL(redirectTo, request.url));
+  response.cookies.set(TERMS_AGREED_COOKIE, '1', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: ONE_YEAR,
+  });
+
+  return response;
+}

--- a/app/api/auth/kakao/callback/route.ts
+++ b/app/api/auth/kakao/callback/route.ts
@@ -3,6 +3,8 @@ import { exchangeCodeForToken, getKakaoUser } from '@/lib/auth/kakao';
 import { setSession } from '@/lib/auth/session';
 import type { TokenData } from '@/types/auth';
 
+const TERMS_AGREED_COOKIE = 'blue_terms_agreed';
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get('code');
@@ -29,6 +31,13 @@ export async function GET(request: NextRequest) {
     };
 
     await setSession(user, tokens);
+
+    // 약관 동의 여부 확인 — 미동의 시 동의 화면으로
+    const termsAgreed = request.cookies.get(TERMS_AGREED_COOKIE)?.value;
+    if (!termsAgreed) {
+      return NextResponse.redirect(new URL('/agree', request.url));
+    }
+
     return NextResponse.redirect(new URL('/', request.url));
   } catch (err) {
     console.error('[Kakao callback error]', err);


### PR DESCRIPTION
## 개요
카카오 로그인 완료 후 약관 동의 화면을 표시합니다.

## 동작 흐름
```
카카오 로그인
  → 콜백에서 blue_terms_agreed 쿠키 확인
    → 없음: /agree (약관 동의 화면)
      → 동의 버튼 클릭 → 쿠키 저장(1년) → /
    → 있음: 바로 /
```

## 변경 사항
- `app/agree/page.tsx` — 약관 동의 화면
  - 전체 동의 / 이용약관 / 개인정보처리방침 개별 체크박스
  - 필수 항목 미동의 시 버튼 비활성화
  - 약관 전문 링크 (새 탭)
- `app/api/auth/agree/route.ts` — 동의 처리 API (쿠키 1년 저장)
- `app/api/auth/kakao/callback/route.ts` — 동의 쿠키 확인 로직 추가

## 스크린샷
/agree 화면: 전체동의 체크박스 + 이용약관/개인정보처리방침 개별 체크 + 동의하고 시작하기 버튼