### PR TITLE
[#71] fix: 주택형별 공급 분양가 표시 버그 수정

### DIFF
--- a/app/api/announcements/detail/route.ts
+++ b/app/api/announcements/detail/route.ts
@@ -17,6 +17,15 @@ function extractThTd(html: string, thText: string): string {
   return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
+function cleanPrice(raw: string): string {
+  // 앞부분 숫자만 추출 (예: "2026000120(02)" → "2026000120")
+  const match = raw.match(/^[\d,]+/);
+  if (!match) return '';
+  const num = parseInt(match[0].replace(/,/g, ''), 10);
+  if (isNaN(num)) return '';
+  return num.toLocaleString('ko-KR');
+}
+
 function extractTableRows(html: string, headerKeyword: string): string[][] {
   // Find table that contains a th with headerKeyword
   const tableRe = /<table[\s\S]*?<\/table>/gi;
@@ -94,10 +103,10 @@ export async function GET(request: Request) {
     const units = unitRows
       .filter((row) => row[0] && /^\d/.test(row[0]))
       .map((row) => ({
-        type: row[0] ?? '',
+        type: (row[0] ?? '').trim(),
         supplyArea: row[1] ?? '',
         totalCount: row[4] ?? row[3] ?? '',
-        price: row[5] ?? row[6] ?? '',
+        price: cleanPrice(row[5] ?? row[6] ?? ''),
       }));
 
     const detail: AnnouncementDetail = {


### PR DESCRIPTION
## Summary
- 분양가 셀에 `(02)` 등 부가 텍스트가 혼입되어 `2026000120(02)만원` 형태로 잘못 표시되던 버그 수정
- `cleanPrice()` 헬퍼 추가: 앞부분 숫자만 추출 후 천 단위 콤마 포맷팅
- `type` 필드 `.trim()` 처리로 주택형 코드 공백 정규화

## 변경 파일
- `app/api/announcements/detail/route.ts`

## Test plan
- [ ] 주택형별 공급 섹션에서 분양가가 `20,000만원` 형태로 정상 표시되는지 확인
- [ ] 분양가 없는 공고에서 `-` 표시 정상 확인
- [ ] 주택형 코드 앞뒤 공백 없이 표시되는지 확인

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)