### PR TITLE
[#73] feat: 분양가 한국식 억/만 단위 표시

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -34,6 +34,16 @@ const REGION_OPTIONS = [
   '제주특별자치도',
 ];
 
+function formatPriceKorean(raw: string): string {
+  const num = parseInt(raw.replace(/,/g, ''), 10);
+  if (isNaN(num) || num <= 0) return '-';
+  const 억 = Math.floor(num / 10000);
+  const 만 = num % 10000;
+  if (억 > 0 && 만 > 0) return `${억}억 ${만.toLocaleString('ko-KR')}만원`;
+  if (억 > 0) return `${억}억`;
+  return `${만.toLocaleString('ko-KR')}만원`;
+}
+
 const tierBadgeStyle: Record<string, string> = {
   S: 'bg-yellow-100 text-yellow-700',
   A: 'bg-blue-100 text-blue-700',
@@ -642,7 +652,7 @@ function AnnouncementDetail({ announcement, scoreData }: { announcement: Announc
                     <p className="text-xs font-semibold text-gray-800 mb-1">{u.type}</p>
                     <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-gray-600">
                       <span>세대수 <span className="font-medium text-gray-800">{u.totalCount || '-'}</span></span>
-                      <span>분양가 <span className="font-medium text-gray-800">{u.price ? `${u.price}만원` : '-'}</span></span>
+                      <span>분양가 <span className="font-medium text-gray-800">{u.price ? formatPriceKorean(u.price) : '-'}</span></span>
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- 분양가를 숫자 나열(`2,026,000,217만원`) 대신 한국식 억/만 단위로 변환하여 가독성 개선
- `formatPriceKorean()` 함수 추가

## 변환 예시
| 입력 (만원) | 표시 |
|------------|------|
| 20,260 | 2억 260만원 |
| 50,000 | 5억 |
| 3,500 | 3,500만원 |
| 없음 | - |

## 변경 파일
- `app/announcements/page.tsx`

## Test plan
- [ ] 분양가가 억 단위 이상인 공고에서 `X억 X만원` 형태로 표시 확인
- [ ] 나머지 만이 0인 경우 `X억` 으로만 표시 확인
- [ ] 1억 미만은 `X,XXX만원` 형태 확인
- [ ] 분양가 없는 경우 `-` 확인

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)