### PR TITLE
[#75] feat: 지역 필터 수평 스크롤 + 마지막 선택 지역 기억

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -58,6 +58,11 @@ export default function AnnouncementsPage() {
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedRegion, setSelectedRegion] = useState('전체');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('preferred_region');
+    if (saved && REGION_OPTIONS.includes(saved)) setSelectedRegion(saved);
+  }, []);
   const [isMock, setIsMock] = useState(false);
   const [hideExpired, setHideExpired] = useState(true);
   const [selectedAnnouncement, setSelectedAnnouncement] = useState<Announcement | null>(null);
@@ -276,12 +281,15 @@ export default function AnnouncementsPage() {
               </button>
             </div>
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div className="flex overflow-x-auto gap-2 pb-1 scrollbar-hide">
             {REGION_OPTIONS.map((region) => (
               <button
                 key={region}
-                onClick={() => setSelectedRegion(region)}
-                className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
+                onClick={() => {
+                  setSelectedRegion(region);
+                  localStorage.setItem('preferred_region', region);
+                }}
+                className={`flex-shrink-0 px-3 py-1.5 rounded-full text-xs font-semibold transition-all ${
                   selectedRegion === region
                     ? 'bg-blue-600 text-white shadow-sm'
                     : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,3 +33,11 @@ body {
 .animate-slide-up {
   animation: slide-up 0.25s ease-out;
 }
+
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- 지역 필터 레이아웃을 `flex-wrap` → 수평 스크롤 단일 행으로 변경해 화면 공간 확보
- `scrollbar-hide` CSS 추가로 스크롤바 숨김, 모바일 스와이프 UX 적용
- `localStorage`에 마지막 선택 지역 저장 → 재접속 시 자동 복원 (로그인 여부 무관)

## 변경 전/후
| 전 | 후 |
|---|---|
| 17개 버튼 전체 나열 (flex-wrap) | 한 줄 가로 스와이프 |
| 매번 전체 지역 초기화 | 마지막 선택 지역 자동 복원 |

## 변경 파일
- `app/announcements/page.tsx` — 수평 스크롤 + localStorage 저장/로드
- `app/globals.css` — `.scrollbar-hide` 유틸 추가

## Test plan
- [ ] 지역 필터가 한 줄 가로 스크롤로 표시되는지 확인
- [ ] 모바일에서 좌우 스와이프로 지역 탐색 가능한지 확인
- [ ] 지역 선택 후 새로고침 시 동일 지역이 선택되어 있는지 확인
- [ ] 서울 선택 → 탭 닫기 → 재접속 시 서울이 기본값으로 설정되는지 확인

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)